### PR TITLE
Provide greater support to older Android versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This authentication SDK works with the overall AWS SDK. Both SDKs are published 
 Add the following lines to the dependencies section of your build.gradle file in Android Studio:
 
 ```
-implementation("software.amazon.location:auth:0.0.1")
+implementation("software.amazon.location:auth:0.0.2")
 implementation("com.amazonaws:aws-android-sdk-location:2.72.0")
 ```
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -45,7 +45,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -10,7 +10,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
 
-    coordinates("software.amazon.location", "auth", "0.0.1")
+    coordinates("software.amazon.location", "auth", "0.0.2")
 
     pom {
         name.set("My Library")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Setting minimum Android API level to 21 (Android 5) to provide a greater supported Android versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
