### PR TITLE
Add GitHub build and publish actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
+      
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  # cancel jobs on PRs only
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
+
+      - name: Build with Gradle
+        run: ./gradlew build
       
       - name: Publish to Maven Central
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_AuthSDKUsername: ${{ secrets.SONATYPE_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_AuthSDKPassword: ${{ secrets.SONATYPE_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_ACCOUNT_GPG_KEY_PASSWORD }}
+        run: ./gradlew publishAllPublicationsToAuthSDKRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,4 @@
 plugins {
   id("org.jetbrains.kotlin.android") version "1.9.0" apply false
   id("com.android.library") version "8.2.2" apply false
-  id("com.gradleup.nmcp") version "0.0.4"
-}
-
-nmcp {
-  publishAllProjectsProbablyBreakingProjectIsolation {
-    username = findProperty("mavenCentralUsername").toString()
-    password = findProperty("mavenCentralPassword").toString()
-    publicationType = "AUTOMATIC"
-  }
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -20,7 +20,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
 
-    coordinates("software.amazon.location", "auth", "0.2.2")
+    coordinates("software.amazon.location", "auth", "0.2.4")
 
     pom {
         name.set("Amazon Location Service Mobile Authentication SDK for Android")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,6 +1,42 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("com.vanniktech.maven.publish") version "0.27.0"
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+    signAllPublications()
+
+    coordinates("software.amazon.location", "auth", "0.2.0")
+
+    pom {
+        name.set("Amazon Location Service Mobile Authentication SDK for Android")
+        description.set("These utilities help you authenticate when making Amazon Location Service API calls from your Android applications.")
+        inceptionYear.set("2024")
+        url.set("https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-android")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("aws-geospatial")
+                name.set("AWS Geospatial")
+                url.set("https://github.com/aws-geospatial")
+            }
+        }
+        scm {
+            url.set("https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-android")
+            connection.set("scm:git:git://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-android")
+            developerConnection.set("scm:git:ssh://git@github.com/aws-geospatial/amazon-location-mobile-auth-sdk-android")
+        }
+    }
 }
 
 android {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -20,7 +20,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()
 
-    coordinates("software.amazon.location", "auth", "0.2.0")
+    coordinates("software.amazon.location", "auth", "0.2.2")
 
     pom {
         name.set("Amazon Location Service Mobile Authentication SDK for Android")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,42 +1,6 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
-    id("com.vanniktech.maven.publish") version "0.27.0"
-}
-
-mavenPublishing {
-    publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
-    signAllPublications()
-
-    coordinates("software.amazon.location", "auth", "0.0.2")
-
-    pom {
-        name.set("My Library")
-        description.set("A description of what my library does.")
-        inceptionYear.set("2020")
-        url.set("https://github.com/username/mylibrary/")
-        licenses {
-            license {
-                name.set("The Apache License, Version 2.0")
-                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-            }
-        }
-        developers {
-            developer {
-                id.set("username")
-                name.set("User Name")
-                url.set("https://github.com/username/")
-            }
-        }
-        scm {
-            url.set("https://github.com/username/mylibrary/")
-            connection.set("scm:git:git://github.com/username/mylibrary.git")
-            developerConnection.set("scm:git:ssh://git@github.com/username/mylibrary.git")
-        }
-    }
 }
 
 android {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -6,6 +6,16 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.27.0"
 }
 
+publishing {
+    repositories {
+        maven {
+            name = "AuthSDK"
+            url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials(PasswordCredentials::class)
+        }
+    }
+}
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
     signAllPublications()


### PR DESCRIPTION
*Description of changes:* This change adds GitHub Actions CI/CD support. The build action will run on every pull request. The publish action will run on every release.

AWS has its own unique Maven Central endpoint and its own unique authentication process, so most of the public documentation will not work. We are using a plugin to help us adapt the workflow for this specific endpoint.

The publish action relies on repository-level secrets that can be configured by admins on the Settings tab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
