### PR TITLE
fix(github): reduced workflow permission scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -24,7 +24,7 @@ jobs:
           ./gradlew testDebugUnitTest
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
 jobs:
   test-android:
+    permissions:
+      contents: read
+      actions: write
     name: Test Android
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:*

Address Code Scan results

*Description of changes:*

Reduce github workflow permissions to read only, with write actions when artifact upload is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
