### PR TITLE
Add Android API key restriction headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ HttpRequestUtil.setOkHttpClient(
 )
 ```
 
+### Using API Key Android App Restrictions
+
+If your API key is configured with [Android app restrictions](https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html), the SDK automatically attaches the required `X-Android-Package` and `X-Android-Cert` headers to all API key requests made through the SDK clients and `AwsSignerInterceptor`. The SDK reads the package name and signing certificate fingerprint from your app automatically.
+
+For MapLibre map tile requests, use `MapHttpClientProvider`:
+
+```
+MapLibre.getInstance(this)
+HttpRequestUtil.setOkHttpClient(MapHttpClientProvider.getMapHttpClient(applicationContext))
+```
+
 You can use the created clients to make calls to Amazon Location Service. Here is an example that searches for places near a specified latitude and longitude:
 
 ```

--- a/library/src/main/java/software/amazon/location/auth/AndroidAppIdentityProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/AndroidAppIdentityProvider.kt
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.location.auth
+
+/**
+ * Provides Android application identity for API key request headers.
+ */
+interface AndroidAppIdentityProvider {
+    val packageName: String
+    val certFingerprint: String?
+}

--- a/library/src/main/java/software/amazon/location/auth/ApiKeyInterceptor.kt
+++ b/library/src/main/java/software/amazon/location/auth/ApiKeyInterceptor.kt
@@ -3,6 +3,7 @@
 
 package software.amazon.location.auth
 
+import android.content.Context
 import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
 import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
@@ -13,15 +14,29 @@ import software.amazon.location.auth.utils.Constants.QUERY_PARAM_KEY
 
 class ApiKeyInterceptor(
     private val apiKey: String,
+    private val appIdentityProvider: AndroidAppIdentityProvider? = null,
 ) : HttpInterceptor {
+
+    constructor(apiKey: String, context: Context) : this(
+        apiKey,
+        DefaultAndroidAppIdentityProvider(context)
+    )
+
     override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         val req = context.protocolRequest.toBuilder()
 
+        appIdentityProvider?.let { provider ->
+            req.headers.append("X-Android-Package", provider.packageName)
+            provider.certFingerprint?.let { fingerprint ->
+                req.headers.append("X-Android-Cert", fingerprint)
+            }
+        }
+
         return if (!context.protocolRequest.url.toString().contains("$QUERY_PARAM_KEY=")) {
-            req.url(Url.parse(context.protocolRequest.url.toString()+"?$QUERY_PARAM_KEY=$apiKey"))
+            req.url(Url.parse(context.protocolRequest.url.toString() + "?$QUERY_PARAM_KEY=$apiKey"))
             req.build()
         } else {
-            super.modifyBeforeSigning(context)
+            req.build()
         }
     }
 }

--- a/library/src/main/java/software/amazon/location/auth/AwsSignerInterceptor.kt
+++ b/library/src/main/java/software/amazon/location/auth/AwsSignerInterceptor.kt
@@ -58,8 +58,13 @@ class AwsSignerInterceptor(
             } else {
                 originalHttpUrl
             }
+            val identityProvider = DefaultAndroidAppIdentityProvider(context)
             val newRequest = originalRequest.newBuilder()
                 .url(newHttpUrl)
+                .header("X-Android-Package", identityProvider.packageName)
+                .apply {
+                    identityProvider.certFingerprint?.let { header("X-Android-Cert", it) }
+                }
                 .build()
 
             return chain.proceed(newRequest)

--- a/library/src/main/java/software/amazon/location/auth/DefaultAndroidAppIdentityProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/DefaultAndroidAppIdentityProvider.kt
@@ -16,8 +16,7 @@ class DefaultAndroidAppIdentityProvider(private val context: Context) : AndroidA
     override val packageName: String
         get() = context.packageName
 
-    override val certFingerprint: String?
-        get() = getSigningCertFingerprint()
+    override val certFingerprint: String? by lazy { getSigningCertFingerprint() }
 
     private fun getSigningCertFingerprint(): String? {
         return try {

--- a/library/src/main/java/software/amazon/location/auth/DefaultAndroidAppIdentityProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/DefaultAndroidAppIdentityProvider.kt
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.location.auth
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import java.security.MessageDigest
+
+/**
+ * Default implementation that reads package name and signing certificate from Android Context.
+ */
+class DefaultAndroidAppIdentityProvider(private val context: Context) : AndroidAppIdentityProvider {
+
+    override val packageName: String
+        get() = context.packageName
+
+    override val certFingerprint: String?
+        get() = getSigningCertFingerprint()
+
+    private fun getSigningCertFingerprint(): String? {
+        return try {
+            val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val packageInfo = context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.GET_SIGNING_CERTIFICATES
+                )
+                packageInfo.signingInfo?.apkContentsSigners
+            } else {
+                @Suppress("DEPRECATION")
+                val packageInfo = context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.GET_SIGNATURES
+                )
+                @Suppress("DEPRECATION")
+                packageInfo.signatures
+            }
+            val signature = signatures?.firstOrNull() ?: return null
+            val md = MessageDigest.getInstance("SHA-1")
+            val digest = md.digest(signature.toByteArray())
+            digest.joinToString(":") { "%02X".format(it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/library/src/main/java/software/amazon/location/auth/LocationCredentialsProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/LocationCredentialsProvider.kt
@@ -132,7 +132,7 @@ class LocationCredentialsProvider {
                     val apiKey = securePreferences.get(API_KEY) ?: throw Exception("API key not found")
                     this.region = region
                     this.credentialsProvider = createEmptyCredentialsProvider()
-                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey))
+                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey, this@LocationCredentialsProvider.context))
                 }
                 else -> {
                     this.region = region
@@ -160,7 +160,7 @@ class LocationCredentialsProvider {
                     val apiKey = securePreferences.get(API_KEY) ?: throw Exception("API key not found")
                     this.region = region
                     this.credentialsProvider = createEmptyCredentialsProvider()
-                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey))
+                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey, this@LocationCredentialsProvider.context))
                 }
                 else -> {
                     this.region = region
@@ -188,7 +188,7 @@ class LocationCredentialsProvider {
                     val apiKey = securePreferences.get(API_KEY) ?: throw Exception("API key not found")
                     this.region = region
                     this.credentialsProvider = createEmptyCredentialsProvider()
-                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey))
+                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey, this@LocationCredentialsProvider.context))
                 }
                 else -> {
                     this.region = region
@@ -216,7 +216,7 @@ class LocationCredentialsProvider {
                     val apiKey = securePreferences.get(API_KEY) ?: throw Exception("API key not found")
                     this.region = region
                     this.credentialsProvider = createEmptyCredentialsProvider()
-                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey))
+                    this.interceptors = mutableListOf(ApiKeyInterceptor(apiKey, this@LocationCredentialsProvider.context))
                 }
                 else -> {
                     this.region = region

--- a/library/src/main/java/software/amazon/location/auth/MapHttpClientProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/MapHttpClientProvider.kt
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.location.auth
+
+import android.content.Context
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+
+/**
+ * Provides a pre-configured OkHttpClient for use with MapLibre's HttpRequestUtil.
+ * This client automatically attaches X-Android-Package and X-Android-Cert headers
+ * to all map tile requests, enabling API key Android app restrictions.
+ *
+ * Usage:
+ * ```
+ * val mapHttpClient = LocationCredentialsProvider.getMapHttpClient(context)
+ * HttpRequestUtil.setOkHttpClient(mapHttpClient)
+ * MapLibre.getInstance(this)
+ * ```
+ */
+object MapHttpClientProvider {
+
+    /**
+     * Creates an OkHttpClient that attaches Android app identity headers to all requests.
+     * Use with MapLibre's HttpRequestUtil.setOkHttpClient() to enable API key Android restrictions
+     * for map tile requests.
+     *
+     * @param context The application context.
+     * @return A configured OkHttpClient with the Android identity headers interceptor.
+     */
+    fun getMapHttpClient(context: Context): OkHttpClient {
+        val identityProvider = DefaultAndroidAppIdentityProvider(context)
+        return OkHttpClient.Builder()
+            .addInterceptor(Interceptor { chain ->
+                val requestBuilder = chain.request().newBuilder()
+                requestBuilder.addHeader("X-Android-Package", identityProvider.packageName)
+                identityProvider.certFingerprint?.let { fingerprint ->
+                    requestBuilder.addHeader("X-Android-Cert", fingerprint)
+                }
+                chain.proceed(requestBuilder.build())
+            })
+            .build()
+    }
+}

--- a/library/src/main/java/software/amazon/location/auth/MapHttpClientProvider.kt
+++ b/library/src/main/java/software/amazon/location/auth/MapHttpClientProvider.kt
@@ -14,9 +14,8 @@ import okhttp3.OkHttpClient
  *
  * Usage:
  * ```
- * val mapHttpClient = LocationCredentialsProvider.getMapHttpClient(context)
- * HttpRequestUtil.setOkHttpClient(mapHttpClient)
  * MapLibre.getInstance(this)
+ * HttpRequestUtil.setOkHttpClient(MapHttpClientProvider.getMapHttpClient(this))
  * ```
  */
 object MapHttpClientProvider {

--- a/library/src/test/java/software/amazon/location/auth/ApiKeyInterceptorTest.kt
+++ b/library/src/test/java/software/amazon/location/auth/ApiKeyInterceptorTest.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.net.url.Url
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -50,10 +51,58 @@ class ApiKeyInterceptorTest {
 
         every { mockContext.protocolRequest } returns httpRequest
 
-        // Act
         val resultRequest = apiKeyInterceptor.modifyBeforeSigning(mockContext)
 
-        // Assert
         assertEquals("$TEST_URL1?key=existingKey", resultRequest.url.toString())
+    }
+
+    @Test
+    fun `test Android headers are set when identity provider is provided`() = runBlocking {
+        val mockProvider = mockk<AndroidAppIdentityProvider>()
+        every { mockProvider.packageName } returns "com.example.testapp"
+        every { mockProvider.certFingerprint } returns "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+
+        val interceptor = ApiKeyInterceptor(apiKey, mockProvider)
+
+        val mockContext = mockk<ProtocolRequestInterceptorContext<Any, HttpRequest>>(relaxed = true)
+        val httpRequest = HttpRequest(method = HttpMethod.POST, url = Url.parse(TEST_URL1))
+        every { mockContext.protocolRequest } returns httpRequest
+
+        val resultRequest = interceptor.modifyBeforeSigning(mockContext)
+
+        assertEquals("com.example.testapp", resultRequest.headers["X-Android-Package"])
+        assertEquals("AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD", resultRequest.headers["X-Android-Cert"])
+    }
+
+    @Test
+    fun `test no Android headers when identity provider is null`() = runBlocking {
+        val interceptor = ApiKeyInterceptor(apiKey)
+
+        val mockContext = mockk<ProtocolRequestInterceptorContext<Any, HttpRequest>>(relaxed = true)
+        val httpRequest = HttpRequest(method = HttpMethod.POST, url = Url.parse(TEST_URL1))
+        every { mockContext.protocolRequest } returns httpRequest
+
+        val resultRequest = interceptor.modifyBeforeSigning(mockContext)
+
+        assertNull(resultRequest.headers["X-Android-Package"])
+        assertNull(resultRequest.headers["X-Android-Cert"])
+    }
+
+    @Test
+    fun `test cert header not set when fingerprint is null`() = runBlocking {
+        val mockProvider = mockk<AndroidAppIdentityProvider>()
+        every { mockProvider.packageName } returns "com.example.testapp"
+        every { mockProvider.certFingerprint } returns null
+
+        val interceptor = ApiKeyInterceptor(apiKey, mockProvider)
+
+        val mockContext = mockk<ProtocolRequestInterceptorContext<Any, HttpRequest>>(relaxed = true)
+        val httpRequest = HttpRequest(method = HttpMethod.POST, url = Url.parse(TEST_URL1))
+        every { mockContext.protocolRequest } returns httpRequest
+
+        val resultRequest = interceptor.modifyBeforeSigning(mockContext)
+
+        assertEquals("com.example.testapp", resultRequest.headers["X-Android-Package"])
+        assertNull(resultRequest.headers["X-Android-Cert"])
     }
 }


### PR DESCRIPTION
## Summary

Automatically attach `X-Android-Package` and `X-Android-Cert` headers to all API key authenticated requests. This enables customers to use API keys with Android app restrictions without needing to manually set headers.

## Changes

- **`AndroidAppIdentityProvider`** — interface for providing app identity (package name + cert fingerprint)
- **`DefaultAndroidAppIdentityProvider`** — implementation using Android Context
- **`ApiKeyInterceptor`** — attaches headers on every API key request via the provider
- **`LocationCredentialsProvider`** — passes context to the interceptor in all client config methods
- **Unit tests** — verifies headers are set/unset correctly

## Testing

- Verified end-to-end on Android emulator with an API key configured with Android restrictions
- Map tiles and Places API calls succeed with headers present, fail without them
- Also verified end-to-end on Android emulator with an API key configured without Android restrictions

Resolves #23